### PR TITLE
Page Admin Message terminé

### DIFF
--- a/resources/views/adminPage.blade.php
+++ b/resources/views/adminPage.blade.php
@@ -3,19 +3,17 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">            
             {{-- admin page --}}
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm rounded-lg mb-3 md:mb-5 mt-14 xl:mt-0">
-                <div class="tabs p-6 text-gray-900 dark:text-gray-100">
+                <div class="tabs p-6 text-gray-900 dark:text-gray-100 flex">
                     <!-- Les blocs sont maintenant des liens entièrement cliquables -->
-                    <a href="javascript:void(0);" class="tab active" id="allAdmin-tab" onclick="showContent('allAdmin')">
+                    <a href="javascript:void(0);" class="tab active flex-1" id="allAdmin-tab" onclick="showContent('allAdmin')">
                         Post à traiter
                     </a>
-                    @auth
-                    <a href="javascript:void(0);" class="tab" id="postTraiter-tab" onclick="showContent('postTraiter')">
-                        post traité
+                    <a href="javascript:void(0);" class="tab flex-1" id="postTraiter-tab" onclick="showContent('postTraiter')">
+                        Post traité
                     </a>
-                    <a href="javascript:void(0);" class="tab" id="UtilisateurBanni-tab" onclick="showContent('UtilisateurBanni')">
-                        Utilisateur Banni
+                    <a href="javascript:void(0);" class="tab flex-1" id="UtilisateurBanni-tab" onclick="showContent('UtilisateurBanni')">
+                        Utilisateurs Bannis (pour un post)
                     </a>
-                    @endauth
                 </div>
             </div>
 
@@ -24,14 +22,12 @@
                     <div id="allAdmin-content" class="content-section" style="display: block;">
                         <livewire:admin.viewall />
                     </div>
-                    @auth
                     <div id="postTraiter-content" class="content-section" style="display: none;">
                         <livewire:admin.viewall-traiter/>
                     </div>
                     <div id="UtilisateurBanni-content" class="content-section" style="display: none;">
                         <livewire:admin.viewall-banned/>
                     </div>
-                    @endauth
                 </div>
             </div>
 

--- a/resources/views/adminPageMessage.blade.php
+++ b/resources/views/adminPageMessage.blade.php
@@ -8,15 +8,16 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <!-- admin page -->
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm rounded-lg mb-3 md:mb-5 mt-14 xl:mt-0">
-                <div class="tabs p-6 text-gray-900 dark:text-gray-100">
-                    <a href="javascript:void(0);" class="tab active" id="allAdmin-tab" data-target="allAdmin-content">
+                <div class="tabs p-6 text-gray-900 dark:text-gray-100 flex">
+                    <a href="javascript:void(0);" class="tab flex-1" id="allAdmin-tab" data-target="allAdmin-content">
                         Message à traiter
                     </a>
-                    @auth
-                    <a href="javascript:void(0);" class="tab" id="postTraiter-tab" data-target="postTraiter-content">
+                    <a href="javascript:void(0);" class="tab flex-1" id="messageTraiter-tab" data-target="messageTraiter-content">
                         Message traité
                     </a>
-                    @endauth
+                    <a href="javascript:void(0);" class="tab flex-1" id="UtilisateurBanni-tab" data-target="UtilisateursBannis-content">
+                        Utilisateurs bannis (pour un message)
+                    </a>
                 </div>
             </div>
 
@@ -25,11 +26,12 @@
                     <div id="allAdmin-content" class="content-section content-active">
                         <livewire:admin.viewallMessage />
                     </div>
-                    @auth
-                    <div id="postTraiter-content" class="content-section">
+                    <div id="messageTraiter-content" class="content-section">
                         <livewire:admin.viewallMessageTraiter />
                     </div>
-                    @endauth
+                    <div id="UtilisateursBannis-content" class="content-section">
+                        <livewire:admin.viewall-banned/>
+                    </div>
                 </div>
             </div>
 
@@ -80,18 +82,35 @@
             const tabs = document.querySelectorAll('.tab');
             const contents = document.querySelectorAll('.content-section');
 
+            // Récupérer l'onglet actif depuis localStorage
+            const activeTab = localStorage.getItem('activeTab') || 'allAdmin-tab';
+
+            // Fonction pour afficher le contenu de l'onglet actif
+            function showTab(tabId) {
+                // Remove active class from all tabs and contents
+                tabs.forEach(t => t.classList.remove('active'));
+                contents.forEach(c => c.classList.remove('content-active'));
+
+                // Add active class to the clicked tab and corresponding content
+                const activeTabElement = document.getElementById(tabId);
+                activeTabElement.classList.add('active');
+                const target = document.getElementById(activeTabElement.getAttribute('data-target'));
+                target.classList.add('content-active');
+            }
+
+            // Afficher l'onglet actif lors du chargement de la page
+            showTab(activeTab);
+
             tabs.forEach(tab => {
                 tab.addEventListener('click', () => {
-                    // Remove active class from all tabs and contents
-                    tabs.forEach(t => t.classList.remove('active'));
-                    contents.forEach(c => c.classList.remove('content-active'));
-
-                    // Add active class to the clicked tab and corresponding content
-                    tab.classList.add('active');
-                    const target = document.getElementById(tab.getAttribute('data-target'));
-                    target.classList.add('content-active');
+                    // Enregistrer l'onglet actif dans localStorage
+                    localStorage.setItem('activeTab', tab.id);
+                    showTab(tab.id); // Afficher le nouvel onglet
                 });
             });
+
+            // Envoyer l'event pour reset le contenu des tabs
+            this.dispatchEvent(new Event('reset-messages-views'));
         });
     </script>
 </x-app-layout>

--- a/resources/views/components/post-forms.blade.php
+++ b/resources/views/components/post-forms.blade.php
@@ -24,4 +24,5 @@
     <livewire:posts.report />
     <livewire:admin.bans />
     <livewire:admin.warnings />
+    <livewire:admin.delete-message />
 </div>

--- a/resources/views/components/post-view-admin-Traiter.blade.php
+++ b/resources/views/components/post-view-admin-Traiter.blade.php
@@ -10,7 +10,7 @@
             <span class="font-bold text-lg mr-4">Reporté par : </span>
             <a href="/user/{{$post->reporter_id}}" onclick="event.stopPropagation()"
                 class="flex flex-row mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
-                <img src="{{ \App\Models\User::find($post->reporter_id)->getAvatar() }}" alt="Profile Image"
+                <img src="{{ \App\Models\User::find($post->reporter_id)->getAvatar() }}" alt="Image de profil"
                     class="w-8 h-8 rounded-full mr-2 shadow-lg hover:outline hover:outline-2 hover:outline-black/10">
                 <span
                     class="mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 hover:underline dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
@@ -23,7 +23,7 @@
             <span class="font-bold text-lg mr-4">Propriétaire du post : </span>
             <a href="/user/{{$post->owner_id}}" onclick="event.stopPropagation()"
                 class="flex flex-row mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-gray-400 mb-2 transition duration-150 ease-in-out">
-                <img src="{{ $post->user->getAvatar() }}" alt="Profile Image"
+                <img src="{{ $post->user->getAvatar() }}" alt="Image de profil"
                     class="w-8 h-8 rounded-full mr-2 shadow-lg hover:outline hover:outline-2 hover:outline-black/10">
                 <span
                     class="mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 hover:underline dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
@@ -31,9 +31,17 @@
                 </span>
             </a>
         </div>
-        <div class="flex sm:flex-row flex-col sm:text-base text-lg items-center sm:mb-4 cursor-text mb-6" onclick="event.stopPropagation()">
+        <div class="flex sm:flex-row flex-col sm:text-base text-lg items-center cursor-text" onclick="event.stopPropagation()">
             <strong class="mr-1">Raison du report : </strong> {{ $post->reports_reason }}
         </div>
+        @php
+            Carbon\Carbon::setLocale('fr');
+            $date = $post->reports_date ? Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $post->reports_date) : null;
+        @endphp
+        <div class="flex sm:flex-row flex-col sm:text-base text-lg items-center sm:mb-4 cursor-text mb-6" onclick="event.stopPropagation()">
+            <strong class="mr-1">Reporté le : </strong> {{ $date->translatedFormat('d F Y \à H:i') }}
+        </div>
+
         <div class="flex sm:flex-row flex-col sm:space-y-0 space-y-8 items-center">
 
             <!-- Avertissement -->
@@ -60,7 +68,7 @@
 
             <!-- Bannir l'utilisateur -->
             @if (App\Models\Ban::where('user_id', $post->owner_id)->first())
-            <livewire:admin.unban :userId="$post->owner_id"/>
+            <livewire:admin.unban :userId="$post->owner_id" :reportType="'Report'"/>
             @else 
             <button title="Marqué le report comme traité bannir l'utilisateur et cacher son post"
                 class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-800 dark:hover:text-red-500 mr-4"

--- a/resources/views/components/post-view-admin.blade.php
+++ b/resources/views/components/post-view-admin.blade.php
@@ -30,8 +30,15 @@
                 </span>
             </a>
         </div>
-        <div class="flex sm:flex-row flex-col sm:text-base text-lg items-center sm:mb-4 cursor-text mb-6" onclick="event.stopPropagation()">
+        <div class="flex sm:flex-row flex-col sm:text-base text-lg items-center cursor-text" onclick="event.stopPropagation()">
             <strong class="mr-1">Raison du report : </strong> {{ $post->reports_reason }}
+        </div>
+        @php
+            Carbon\Carbon::setLocale('fr');
+            $date = $post->reports_date ? Carbon\Carbon::createFromFormat('Y-m-d H:i:s', $post->reports_date) : null;
+        @endphp
+        <div class="flex sm:flex-row flex-col sm:text-base text-lg items-center sm:mb-4 cursor-text mb-6" onclick="event.stopPropagation()">
+            <strong class="mr-1">Reporté le : </strong> {{ $date->translatedFormat('d F Y \à H:i') }}
         </div>
         <div class="flex sm:flex-row flex-col sm:space-y-0 space-y-8 items-center">
 

--- a/resources/views/livewire/admin/bans.blade.php
+++ b/resources/views/livewire/admin/bans.blade.php
@@ -8,6 +8,7 @@ use App\Models\Ban;
 use App\Models\Report;
 use App\Models\ReportMessage;
 use App\Models\PrivateMessage;
+use App\Models\GroupMessage;
 use App\Models\Post;
 
 new class extends Component {
@@ -109,7 +110,7 @@ new class extends Component {
         }
 
         // Mettre à jour le post pour qu'il ne doit plus être visible
-        if ($this->reportType == 'Report') {
+        if ($this->reportType === 'Report') {
             $post = Post::find($this->messageOrPostId);
             if ($post) {
                 $post->hidden = 1;
@@ -117,9 +118,13 @@ new class extends Component {
             }
         }
 
-        $this->close();
+        if ($this->reportType === 'Report') {
+            return redirect()->route('adminPage');
+        } else {
+            return redirect()->route('adminPageMessage');
+        }
 
-        return redirect()->route('adminPage');
+        $this->close();
     }
 };
 ?>

--- a/resources/views/livewire/admin/delete-message.blade.php
+++ b/resources/views/livewire/admin/delete-message.blade.php
@@ -6,6 +6,7 @@ use Livewire\Attributes\Locked;
 use App\Models\Post;
 use App\Models\PrivateMessage;
 use App\Models\GroupMessage;
+use App\Models\ReportMessage;
 
 new class extends Component {
     
@@ -40,15 +41,20 @@ new class extends Component {
             $messageClass = $this->messageType === 'PrivateMessage' ? PrivateMessage::class : GroupMessage::class;
 
             $message = $messageClass::find($this->messageId);
+            $reportMessage = ReportMessage::where('message_id', $this->messageId)
+            ->where('message_type', $this->messageType);
+
             if ($message != null) {
+                $reportMessage->delete();
                 $message->delete();
                 $this->dispatch('reset-message-views');
             }
 
+            return redirect()->route('adminPageMessage');
+
             $this->close();
         }
     }
-
 
 }; ?>
 

--- a/resources/views/livewire/admin/false-report-message.blade.php
+++ b/resources/views/livewire/admin/false-report-message.blade.php
@@ -18,7 +18,7 @@ new class extends Component {
             $report->save();
         }
 
-        return redirect()->route('adminPage');
+        return redirect()->route('adminPageMessage');
     }
 };
 ?>

--- a/resources/views/livewire/admin/unban.blade.php
+++ b/resources/views/livewire/admin/unban.blade.php
@@ -10,7 +10,10 @@ new class extends Component {
     #[Locked]
     public int $userId = -1;
 
-    public function unbanUser(int $userId)
+    #[Locked]
+    public string $reportType = '';
+
+    public function unbanUser(int $userId, string $reportType)
     {
         // Trouver le ban de l'utilisateur
         $ban = Ban::where('user_id', $userId)->first();
@@ -19,12 +22,16 @@ new class extends Component {
             $ban->delete(); // Supprime l'enregistrement
         }
 
-        return redirect()->route('adminPage');
+        if ($reportType === 'Report') {
+            return redirect()->route('adminPage');
+        } else {
+            return redirect()->route('adminPageMessage');
+        }
     }
 };
 ?>
 
-<button wire:click="unbanUser({{$userId}})" title="Débannir l'utilisateur"
+<button wire:click="unbanUser({{$userId}}, '{{$reportType}}')" title="Débannir l'utilisateur"
 class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-green-500 dark:hover:blue-green-500 mr-4"
 onclick="event.stopPropagation()">
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">

--- a/resources/views/livewire/admin/viewall-traiter.blade.php
+++ b/resources/views/livewire/admin/viewall-traiter.blade.php
@@ -11,7 +11,7 @@ new class extends Component {
     public function mount()
     {
         // Get posts reported and not handled, selecting reporter and owner data
-        $this->posts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason', 'reports.id as reports_id')
+        $this->posts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason', 'reports.id as reports_id', 'reports.created_at as reports_date')
             ->join('reports', 'posts.id', '=', 'reports.post_id')
             ->join('users as reporter', 'reports.user_id', '=', 'reporter.id')  // Join reporter using user_id
             ->join('users as owner', 'posts.user_id', '=', 'owner.id')  // Join post owner
@@ -28,7 +28,7 @@ new class extends Component {
     public function loadMore()
     {
         if ($this->moreAvailable) {
-            $newPosts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason')
+            $newPosts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason', 'reports.id as reports_id', 'reports.created_at as reports_date')
                 ->join('reports', 'posts.id', '=', 'reports.post_id')
                 ->join('users as reporter', 'reports.user_id', '=', 'reporter.id')  // Join reporter using user_id
                 ->join('users as owner', 'posts.user_id', '=', 'owner.id')  // Join post owner
@@ -50,7 +50,7 @@ new class extends Component {
     #[On('reset-post-views')]
     public function resetPosts()
     {
-        $this->posts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason')
+        $this->posts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason', 'reports.id as reports_id', 'reports.created_at as reports_date')
             ->join('reports', 'posts.id', '=', 'reports.post_id')
             ->join('users as reporter', 'reports.user_id', '=', 'reporter.id')  // Join reporter using user_id
             ->join('users as owner', 'posts.user_id', '=', 'owner.id')  // Join post owner
@@ -78,7 +78,7 @@ new class extends Component {
                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
             </svg>
               
-            Charger plus de posts reporter
+            Charger plus de posts reporté
         </x-primary-button>
     @else
         <div class="dark:text-gray-300 text-center">Il n'y a aucun post traiter.</div>

--- a/resources/views/livewire/admin/viewall.blade.php
+++ b/resources/views/livewire/admin/viewall.blade.php
@@ -11,7 +11,7 @@ new class extends Component {
     public function mount()
     {
         // Get posts reported and not handled, selecting reporter and owner data
-        $this->posts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason', 'reports.id as reports_id')
+        $this->posts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason', 'reports.id as reports_id', 'reports.created_at as reports_date')
             ->join('reports', 'posts.id', '=', 'reports.post_id')
             ->join('users as reporter', 'reports.user_id', '=', 'reporter.id')  // Join reporter using user_id
             ->join('users as owner', 'posts.user_id', '=', 'owner.id')  // Join post owner
@@ -28,7 +28,7 @@ new class extends Component {
     public function loadMore()
     {
         if ($this->moreAvailable) {
-            $newPosts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason')
+            $newPosts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason', 'reports.id as reports_id', 'reports.created_at as reports_date')
                 ->join('reports', 'posts.id', '=', 'reports.post_id')
                 ->join('users as reporter', 'reports.user_id', '=', 'reporter.id')  // Join reporter using user_id
                 ->join('users as owner', 'posts.user_id', '=', 'owner.id')  // Join post owner
@@ -50,7 +50,7 @@ new class extends Component {
     #[On('reset-post-views')]
     public function resetPosts()
     {
-        $this->posts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason')
+        $this->posts = Post::select('posts.*', 'reports.user_id as reporter_id', 'reporter.name as reporter_name', 'owner.id as owner_id', 'owner.name as owner_name', 'reports.reason as reports_reason', 'reports.id as reports_id', 'reports.created_at as reports_date')
             ->join('reports', 'posts.id', '=', 'reports.post_id')
             ->join('users as reporter', 'reports.user_id', '=', 'reporter.id')  // Join reporter using user_id
             ->join('users as owner', 'posts.user_id', '=', 'owner.id')  // Join post owner
@@ -78,7 +78,7 @@ new class extends Component {
                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
             </svg>
               
-            Charger plus de posts reporter
+            Charger plus de posts reporté
         </x-primary-button>
     @else
         <div class="dark:text-gray-300 text-center">Il n'y a plus de post à traiter.</div>

--- a/resources/views/livewire/admin/viewallMessage.blade.php
+++ b/resources/views/livewire/admin/viewallMessage.blade.php
@@ -2,16 +2,97 @@
 
 use Livewire\Volt\Component;
 use App\Models\ReportMessage;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 
 new class extends Component {
     public $reportedMessages;
+    public $moreAvailable = true;
 
     public function mount()
     {
-        $this->reportedMessages = ReportMessage::where('handled', 0)
+        $this->reportedMessages = ReportMessage::select(
+            'report_messages.*',
+            'report_messages.id as report_id',
+            'report_messages.user_id as reporter_id',
+            DB::raw('CASE 
+                WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.sender_id 
+                WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.user_id 
+                END as author_id'),
+            DB::raw('CASE 
+                WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.message 
+                WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.message 
+                END as content')
+        )
+        ->leftJoin('private_messages', 'report_messages.message_id', '=', 'private_messages.id')
+        ->leftJoin('group_messages', 'report_messages.message_id', '=', 'group_messages.id')
+        ->where('handled', 0)
+        ->orderBy('id', 'desc')
+        ->take(10)
+        ->get();
+
+        // Check if there are more pages to load
+        $this->moreAvailable = $this->reportedMessages->count() == 10;
+    }
+
+    public function loadMore()
+    {
+        if ($this->moreAvailable) {
+            $newReportedMessages = ReportMessage::select(
+                'report_messages.*',
+                'report_messages.id as report_id',
+                'report_messages.user_id as reporter_id',
+                DB::raw('CASE 
+                    WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.sender_id 
+                    WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.user_id 
+                    END as author_id'),
+                DB::raw('CASE 
+                    WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.message 
+                    WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.message 
+                    END as content')
+            )
+            ->leftJoin('private_messages', 'report_messages.message_id', '=', 'private_messages.id')
+            ->leftJoin('group_messages', 'report_messages.message_id', '=', 'group_messages.id')
+            ->where('handled', 0)
+            ->where('report_messages.id', '<', $this->reportedMessages->last()->id)
             ->orderBy('id', 'desc')
             ->take(10)
             ->get();
+
+            // Merge the new posts with the existing ones
+            $this->reportedMessages = $this->reportedMessages->concat($newReportedMessages);
+
+            // Check if there are more pages to load
+            $this->moreAvailable = $newReportedMessages->count() == 10;
+        }
+    }
+
+    #[On('reset-message-views')]
+    public function resetMessages()
+    {
+        $this->reportedMessages = ReportMessage::select(
+            'report_messages.*',
+            'report_messages.id as report_id',
+            'report_messages.user_id as reporter_id',
+            DB::raw('CASE 
+                WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.sender_id 
+                WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.user_id 
+                END as author_id'),
+            DB::raw('CASE 
+                WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.message 
+                WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.message 
+                END as content')
+        )
+        ->leftJoin('private_messages', 'report_messages.message_id', '=', 'private_messages.id')
+        ->leftJoin('group_messages', 'report_messages.message_id', '=', 'group_messages.id')
+        ->where('handled', 0)
+        ->orderBy('id', 'desc')
+        ->take(10)
+        ->get();
+
+        // Check if there are more pages to load
+        $this->moreAvailable = $this->reportedMessages->count() == 10;
     }
 };
 
@@ -21,65 +102,114 @@ new class extends Component {
     <div>
         <h5 class="text-xl font-bold mb-4 text-gray-900 dark:text-gray-100">Messages Reportés</h5>
 
-        <div class="ml-4 text-gray-900 dark:text-gray-100 mb-4">
+        <div class="text-gray-900 dark:text-gray-100 mb-4">
             <div class="flex sm:flex-row flex-col sm:space-y-0 space-y-8 items-center">
                 @if($reportedMessages->isEmpty())
-                    <p class="text-lg text-gray-700 dark:text-gray-400">Aucun message reporté non traité trouvé.</p>
+                <p class="text-lg text-gray-700 dark:text-gray-400">Aucun message reporté non traité trouvé.</p>
                 @else
-                    <ul class="w-full">
-                        @foreach($reportedMessages as $message)
-                            <div class="border border-gray-300 rounded-lg p-4 mb-4 shadow-sm bg-white dark:bg-gray-800 transition hover:bg-gray-100 dark:hover:bg-gray-700">
-                                <li class="flex flex-col">
-                                    <span class="text-gray-700 dark:text-gray-300"><strong>Raison:</strong> {{ $message->reason }}</span>
-                                    <span class="text-gray-700 dark:text-gray-300"><strong>Type de message:</strong> {{ $message->message_type }}</span>
-                                    <span class="text-gray-700 dark:text-gray-300"><strong>Créé le:</strong> {{ $message->created_at->format('Y-m-d H:i:s') }}</span>
-                                    <span class="text-gray-700 dark:text-gray-300"><strong>Traité:</strong> {{ $message->handled ? 'Oui' : 'Non' }}</span>
-                                </li>
-                                <div class="flex flex-row">
-                                    <!-- Faux report -->
-                                    <livewire:admin.false-report :reportId="$message->id" />
-
-                                    <!-- Avertissement -->
-                                    <button title="Marqué le report comme traité et envoyer un avertissement à l'utilisateur"
-                                        class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-orange-500 dark:hover:text-orange-400 mr-4"
-                                        onclick="event.stopPropagation(); showWarningModal({{ $message->message_id }}, {{ $message->id }}, 'Report');">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" class="size-6">
-                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46" />
-                                        </svg>
-                                        <span class="ml-1">Envoyer un avertissement</span>
-                                    </button>
-
-                                    <!-- Supprimer post -->
-                                    <button title="Supprimer le message reporté"
-                                        class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 mr-4"
-                                        onclick="event.stopPropagation(); showPostDeletePopup({{ $message->message_id }})">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" class="size-6">
-                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                                        </svg>
-                                        <span class="ml-1">Supprimer le message</span>
-                                    </button>
-
-                                    <!-- Bannir l'utilisateur -->
-                                    <button title="Marqué le report comme traité, bannir l'utilisateur et cacher son message"
-                                        class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-800 dark:hover:text-red-500 mr-4"
-                                        onclick="event.stopPropagation(); showBanUserModal({{ $message->message_id }}, {{ $message->id }}, 'Report');">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" class="size-6">
-                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0 0 12 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 0 1-2.031.352 5.988 5.988 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971Zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 0 1-2.031.352 5.989 5.989 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L4.25 5.491Z" />
-                                        </svg>
-                                        <span class="ml-1">Bannir l'utilisateur</span>
-                                    </button>
-                                </div>
+                <ul class="w-full">
+                    @foreach($reportedMessages as $message)
+                    <div
+                        class="border border-gray-300 rounded-lg p-4 mb-4 shadow-sm bg-white dark:bg-gray-800 transition">
+                        <li class="flex flex-col">
+                            <!-- Personne qui a créer le report -->
+                            <div class="flex sm:flex-row sm:mb-0 mb-4 flex-col items-center">
+                                <span class="font-bold text-lg mr-4">Reporté par : </span>
+                                <a href="/user/{{$message->reporter_id}}" onclick="event.stopPropagation()"
+                                    class="flex flex-row mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
+                                    <img src="{{ User::find($message->reporter_id)->getAvatar() }}"
+                                        alt="Profile Image"
+                                        class="w-8 h-8 rounded-full mr-2 shadow-lg hover:outline hover:outline-2 hover:outline-black/10">
+                                    <span
+                                        class="mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 hover:underline dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
+                                        {{ User::where('id', $message->reporter_id)->value('name') }}
+                                    </span>
+                                </a>
                             </div>
-                        @endforeach
-                    </ul>
+                            <!-- Personne reporté -->
+                            <div class="flex sm:flex-row sm:mb-0 mb-4 flex-col items-center">
+                                <span class="font-bold text-lg mr-4">Auteur du message : </span>
+                                <a href="/user/{{$message->author_id}}" onclick="event.stopPropagation()"
+                                    class="flex flex-row mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-gray-400 mb-2 transition duration-150 ease-in-out">
+                                    <img src="{{ User::find($message->author_id)->getAvatar() }}" alt="Profile Image"
+                                        class="w-8 h-8 rounded-full mr-2 shadow-lg hover:outline hover:outline-2 hover:outline-black/10">
+                                    <span
+                                        class="mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 hover:underline dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
+                                        {{ User::where('id', $message->author_id)->value('name') }}
+                                    </span>
+                                </a>
+                            </div>
+                            @php
+                                Carbon::setLocale('fr');
+                                $date = Carbon::createFromFormat('Y-m-d H:i:s', $message->created_at);
+                            @endphp
+                            <span class="text-[1.08em] text-gray-700 dark:text-gray-300"><strong>Raison:</strong> {{ $message->reason
+                                }}</span>
+                            <span class="text-[1.08em] text-gray-700 dark:text-gray-300"><strong>Reporté le:</strong> {{
+                                $date->translatedFormat('d F Y \à H:i') }}</span>
+                            <span class="text-gray-700 dark:text-gray-300 mb-3"><strong>Type de message:</strong> {{$message->message_type == 'PrivateMessage' ? "message privé" : "message de groupe"}}</span>
+                        </li>
+                        <div class="flex flex-row">
+                            <!-- Faux report -->
+                            <livewire:admin.false-report-message :reportId="$message->id" />
+
+                            <!-- Avertissement -->
+                            <button title="Marqué le report comme traité et envoyer un avertissement à l'utilisateur"
+                                class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-orange-500 dark:hover:text-orange-400 mr-4"
+                                onclick="event.stopPropagation(); showWarningModal({{ $message->author_id }}, {{ $message->report_id }}, {{ $message->message_id }}, 'ReportMessage');">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" stroke="currentColor" class="size-6">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46" />
+                                </svg>
+                                <span class="ml-1">Envoyer un avertissement</span>
+                            </button>
+
+                            <!-- Supprimer post -->
+                            <button title="Supprimer le message reporté"
+                                class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 mr-4"
+                                onclick="event.stopPropagation(); showMessageDeletePopup({{ $message->message_id }}, '{{$message->message_type}}');">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" stroke="currentColor" class="size-6">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                </svg>
+                                <span class="ml-1">Supprimer le message</span>
+                            </button>
+
+                            <!-- Bannir l'utilisateur -->
+                            <button title="Marqué le report comme traité, bannir l'utilisateur et cacher son message"
+                                class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-800 dark:hover:text-red-500 mr-4"
+                                onclick="event.stopPropagation(); showBanUserModal({{ $message->author_id }}, {{ $message->report_id }}, {{ $message->message_id }}, 'ReportMessage');">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" stroke="currentColor" class="size-6">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0 0 12 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 0 1-2.031.352 5.988 5.988 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971Zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 0 1-2.031.352 5.989 5.989 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L4.25 5.491Z" />
+                                </svg>
+                                <span class="ml-1">Bannir l'utilisateur</span>
+                            </button>
+                        </div>
+                        <div class="mt-4">
+                            {{$message->content}}
+                        </div>
+                    </div>
+                    @endforeach
+                </ul>
                 @endif
             </div>
         </div>
+    </div>
+    <div>
+        @if ($moreAvailable)
+            <x-primary-button wire:click='loadMore' class="mt-2 mx-auto !bg-slate-500/90 hover:!bg-slate-700/90 dark:!bg-slate-400/50 dark:hover:!bg-slate-500 dark:!text-gray-100 transition duration-300 ease-in-out">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 mr-3">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+                </svg>
+                  
+                Charger plus de messages reporté
+            </x-primary-button>
+        @else
+            <div class="dark:text-gray-300 text-center">Il n'y a plus de message à traiter.</div>
+        @endif
     </div>
 </div>

--- a/resources/views/livewire/admin/viewallMessageTraiter.blade.php
+++ b/resources/views/livewire/admin/viewallMessageTraiter.blade.php
@@ -2,16 +2,98 @@
 
 use Livewire\Volt\Component;
 use App\Models\ReportMessage;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
 
 new class extends Component {
     public $reportedMessages;
+    public $moreAvailable = true;
 
     public function mount()
     {
-        $this->reportedMessages = ReportMessage::where('handled', 1)
+        $this->reportedMessages = ReportMessage::select(
+            'report_messages.*',
+            'report_messages.id as report_id',
+            'report_messages.user_id as reporter_id',
+            DB::raw('CASE 
+                WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.sender_id 
+                WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.user_id 
+                END as author_id'),
+            DB::raw('CASE 
+                WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.message 
+                WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.message 
+                END as content')
+        )
+        ->leftJoin('private_messages', 'report_messages.message_id', '=', 'private_messages.id')
+        ->leftJoin('group_messages', 'report_messages.message_id', '=', 'group_messages.id')
+        ->where('handled', 1)
+        ->orderBy('id', 'desc')
+        ->take(10)
+        ->get();
+
+        
+        // Check if there are more pages to load
+        $this->moreAvailable = $this->reportedMessages->count() == 10;
+    }
+
+    public function loadMore()
+    {
+        if ($this->moreAvailable) {
+            $newReportedMessages = ReportMessage::select(
+                'report_messages.*',
+                'report_messages.id as report_id',
+                'report_messages.user_id as reporter_id',
+                DB::raw('CASE 
+                    WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.sender_id 
+                    WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.user_id 
+                    END as author_id'),
+                DB::raw('CASE 
+                    WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.message 
+                    WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.message 
+                    END as content')
+            )
+            ->leftJoin('private_messages', 'report_messages.message_id', '=', 'private_messages.id')
+            ->leftJoin('group_messages', 'report_messages.message_id', '=', 'group_messages.id')
+            ->where('handled', 0)
+            ->where('report_messages.id', '<', $this->reportedMessages->last()->id)
             ->orderBy('id', 'desc')
             ->take(10)
             ->get();
+
+            // Merge the new posts with the existing ones
+            $this->reportedMessages = $this->reportedMessages->concat($newReportedMessages);
+
+            // Check if there are more pages to load
+            $this->moreAvailable = $newReportedMessages->count() == 10;
+        }
+    }
+
+    #[On('reset-message-views')]
+    public function resetMessages()
+    {
+        $this->reportedMessages = ReportMessage::select(
+            'report_messages.*',
+            'report_messages.id as report_id',
+            'report_messages.user_id as reporter_id',
+            DB::raw('CASE 
+                WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.sender_id 
+                WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.user_id 
+                END as author_id'),
+            DB::raw('CASE 
+                WHEN report_messages.message_type = \'PrivateMessage\' THEN private_messages.message 
+                WHEN report_messages.message_type = \'GroupMessage\' THEN group_messages.message 
+                END as content')
+        )
+        ->leftJoin('private_messages', 'report_messages.message_id', '=', 'private_messages.id')
+        ->leftJoin('group_messages', 'report_messages.message_id', '=', 'group_messages.id')
+        ->where('handled', 0)
+        ->orderBy('id', 'desc')
+        ->take(10)
+        ->get();
+
+        // Check if there are more pages to load
+        $this->moreAvailable = $this->reportedMessages->count() == 10;
     }
 };
 
@@ -21,65 +103,119 @@ new class extends Component {
     <div>
         <h5 class="text-xl font-bold mb-4 text-gray-900 dark:text-gray-100">Messages Reportés</h5>
 
-        <div class="ml-4 text-gray-900 dark:text-gray-100 mb-4">
+        <div class="text-gray-900 dark:text-gray-100 mb-4">
             <div class="flex sm:flex-row flex-col sm:space-y-0 space-y-8 items-center">
                 @if($reportedMessages->isEmpty())
-                    <p class="text-lg text-gray-700 dark:text-gray-400">Aucun message reporté non traité trouvé.</p>
+                <p class="text-lg text-gray-700 dark:text-gray-400">Aucun message reporté non traité trouvé.</p>
                 @else
-                    <ul class="w-full">
-                        @foreach($reportedMessages as $message)
-                            <div class="border border-gray-300 rounded-lg p-4 mb-4 shadow-sm bg-white dark:bg-gray-800 transition hover:bg-gray-100 dark:hover:bg-gray-700">
-                                <li class="flex flex-col">
-                                    <span class="text-gray-700 dark:text-gray-300"><strong>Raison:</strong> {{ $message->reason }}</span>
-                                    <span class="text-gray-700 dark:text-gray-300"><strong>Type de message:</strong> {{ $message->message_type }}</span>
-                                    <span class="text-gray-700 dark:text-gray-300"><strong>Créé le:</strong> {{ $message->created_at->format('Y-m-d H:i:s') }}</span>
-                                    <span class="text-gray-700 dark:text-gray-300"><strong>Traité:</strong> {{ $message->handled ? 'Oui' : 'Non' }}</span>
-                                </li>
-                                <div class="flex flex-row">
-                                    <!-- Faux report -->
-                                    <livewire:admin.false-report :reportId="$message->id" />
-
-                                    <!-- Avertissement -->
-                                    <button title="Marqué le report comme traité et envoyer un avertissement à l'utilisateur"
-                                        class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-orange-500 dark:hover:text-orange-400 mr-4"
-                                        onclick="event.stopPropagation(); showWarningModal({{ $message->message_id }}, {{ $message->id }}, 'Report');">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" class="size-6">
-                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46" />
-                                        </svg>
-                                        <span class="ml-1">Envoyer un avertissement</span>
-                                    </button>
-
-                                    <!-- Supprimer post -->
-                                    <button title="Supprimer le message reporté"
-                                        class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 mr-4"
-                                        onclick="event.stopPropagation(); showPostDeletePopup({{ $message->message_id }})">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" class="size-6">
-                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-                                        </svg>
-                                        <span class="ml-1">Supprimer le message</span>
-                                    </button>
-
-                                    <!-- Bannir l'utilisateur -->
-                                    <button title="Marqué le report comme traité, bannir l'utilisateur et cacher son message"
-                                        class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-800 dark:hover:text-red-500 mr-4"
-                                        onclick="event.stopPropagation(); showBanUserModal({{ $message->message_id }}, {{ $message->id }}, 'Report');">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                                            stroke-width="1.5" stroke="currentColor" class="size-6">
-                                            <path stroke-linecap="round" stroke-linejoin="round"
-                                                d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0 0 12 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 0 1-2.031.352 5.988 5.988 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971Zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 0 1-2.031.352 5.989 5.989 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L4.25 5.491Z" />
-                                        </svg>
-                                        <span class="ml-1">Bannir l'utilisateur</span>
-                                    </button>
-                                </div>
+                <ul class="w-full">
+                    @foreach($reportedMessages as $message)
+                    <div
+                        class="border border-gray-300 rounded-lg p-4 mb-4 shadow-sm bg-white dark:bg-gray-800 transition hover:bg-gray-100 dark:hover:bg-gray-700">
+                        <li class="flex flex-col">
+                            <!-- Personne qui a créer le report -->
+                            <div class="flex sm:flex-row sm:mb-0 mb-4 flex-col items-center">
+                                <span class="font-bold text-lg mr-4">Reporté par : </span>
+                                <a href="/user/{{$message->reporter_id}}" onclick="event.stopPropagation()"
+                                    class="flex flex-row mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
+                                    <img src="{{ User::find($message->reporter_id)->getAvatar() }}"
+                                        alt="Image de profil"
+                                        class="w-8 h-8 rounded-full mr-2 shadow-lg hover:outline hover:outline-2 hover:outline-black/10">
+                                    <span
+                                        class="mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 hover:underline dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
+                                        {{ User::where('id', $message->reporter_id)->value('name') }}
+                                    </span>
+                                </a>
                             </div>
-                        @endforeach
-                    </ul>
+                            <!-- Personne reporté -->
+                            <div class="flex sm:flex-row sm:mb-0 mb-4 flex-col items-center">
+                                <span class="font-bold text-lg mr-4">Auteur du message : </span>
+                                <a href="/user/{{$message->author_id}}" onclick="event.stopPropagation()"
+                                    class="flex flex-row mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-gray-400 mb-2 transition duration-150 ease-in-out">
+                                    <img src="{{ User::find($message->author_id)->getAvatar() }}"
+                                        alt="Image de profil"
+                                        class="w-8 h-8 rounded-full mr-2 shadow-lg hover:outline hover:outline-2 hover:outline-black/10">
+                                    <span
+                                        class="mr-2 text-lg font-bold text-gray-700 hover:text-gray-900 hover:underline dark:text-white dark:hover:text-gray-400 transition duration-150 ease-in-out">
+                                        {{ User::where('id', $message->author_id)->value('name') }}
+                                    </span>
+                                </a>
+                            </div>
+                            @php
+                                Carbon::setLocale('fr');
+                                $date = Carbon::createFromFormat('Y-m-d H:i:s', $message->created_at);
+                            @endphp
+                            <span class="text-[1.08em] text-gray-700 dark:text-gray-300"><strong>Raison:</strong> {{
+                                $message->reason
+                                }}</span>
+                            <span class="text-[1.08em] text-gray-700 dark:text-gray-300"><strong>Reporté le:</strong> {{
+                                $date->translatedFormat('d F Y \à H:i') }}</span>
+                            <span class="text-gray-700 dark:text-gray-300 mb-3"><strong>Type de message:</strong>
+                                {{$message->message_type == 'PrivateMessage' ? "message privé" : "message de
+                                groupe"}}</span>
+                        </li>
+                        <div class="flex flex-row">
+                            <!-- Avertissement -->
+                            <button title="Marqué le report comme traité et envoyer un avertissement à l'utilisateur"
+                                class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-orange-500 dark:hover:text-orange-400 mr-4"
+                                onclick="event.stopPropagation(); showWarningModal({{ $message->author_id }}, {{ $message->report_id }}, {{ $message->message_id }}, 'ReportMessage');">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" stroke="currentColor" class="size-6">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46" />
+                                </svg>
+                                <span class="ml-1">Envoyer un avertissement</span>
+                            </button>
+
+                            <!-- Supprimer post -->
+                            <button title="Supprimer le message reporté"
+                                class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 mr-4"
+                                onclick="event.stopPropagation(); showMessageDeletePopup({{ $message->message_id }}, '{{$message->message_type}}');">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" stroke="currentColor" class="size-6">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+                                </svg>
+                                <span class="ml-1">Supprimer le message</span>
+                            </button>
+
+                            <!-- Bannir l'utilisateur -->
+                            @if (App\Models\Ban::where('user_id', $message->author_id)->first())
+                            <livewire:admin.unban :userId="$message->author_id" :reportType="'ReportMessage'"/>
+                            @else 
+                            <button title="Marqué le report comme traité, bannir l'utilisateur et cacher son message"
+                                class="repost-button flex items-center text-gray-600 dark:text-gray-400 hover:text-red-800 dark:hover:text-red-500 mr-4"
+                                onclick="event.stopPropagation(); showBanUserModal({{ $message->author_id }}, {{ $message->report_id }}, {{ $message->message_id }}, 'ReportMessage');">
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                                    stroke-width="1.5" stroke="currentColor" class="size-6">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                        d="M12 3v17.25m0 0c-1.472 0-2.882.265-4.185.75M12 20.25c1.472 0 2.882.265 4.185.75M18.75 4.97A48.416 48.416 0 0 0 12 4.5c-2.291 0-4.545.16-6.75.47m13.5 0c1.01.143 2.01.317 3 .52m-3-.52 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.988 5.988 0 0 1-2.031.352 5.988 5.988 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L18.75 4.971Zm-16.5.52c.99-.203 1.99-.377 3-.52m0 0 2.62 10.726c.122.499-.106 1.028-.589 1.202a5.989 5.989 0 0 1-2.031.352 5.989 5.989 0 0 1-2.031-.352c-.483-.174-.711-.703-.59-1.202L4.25 5.491Z" />
+                                </svg>
+                                <span class="ml-1">Bannir l'utilisateur</span>
+                            </button>
+                            @endif
+                        </div>
+                        <div class="mt-4">
+                            {{$message->content}}
+                        </div>
+                    </div>
+                    @endforeach
+                </ul>
                 @endif
             </div>
         </div>
+    </div>
+    <div>
+        @if ($moreAvailable)
+            <x-primary-button wire:click='loadMore' class="mt-2 mx-auto !bg-slate-500/90 hover:!bg-slate-700/90 dark:!bg-slate-400/50 dark:hover:!bg-slate-500 dark:!text-gray-100 transition duration-300 ease-in-out">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 mr-3">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+                </svg>
+                  
+                Charger plus de messages reporté
+            </x-primary-button>
+        @else
+            <div class="dark:text-gray-300 text-center">Il n'y a plus de message à traiter.</div>
+        @endif
     </div>
 </div>

--- a/resources/views/livewire/admin/warnings.blade.php
+++ b/resources/views/livewire/admin/warnings.blade.php
@@ -102,9 +102,13 @@ new class extends Component {
         // Envoyer une notificaiton à l'utilisateur
         User::find($this->userId)->notify(new WarningUser($this->message));
 
-        $this->close();
+        if ($this->reportType === 'Report') {
+            return redirect()->route('adminPage');
+        } else {
+            return redirect()->route('adminPageMessage');
+        }
 
-        return redirect()->route('adminPage');
+        $this->close();
     }
 };
 ?>

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -86,7 +86,7 @@ new class extends Component
                 </x-dropdown>
 
                 <!-- User dropdown -->
-                <x-dropdown align="right" width="w-48">
+                <x-dropdown align="right" width="w-[208px]">
                     <x-slot name="trigger">
                         <button class="inline-flex items-center px-3 pl-1 py-2 border border-transparent text-sm leading-4 font-medium rounded-md 
                             text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 
@@ -120,16 +120,14 @@ new class extends Component
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 mr-2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
                             </svg>
-                            Panel Admin
+                            Panel Admin Posts
                         </x-dropdown-link>
-                        @endif
 
-                        @if (Auth::user()->moderator)
                         <x-dropdown-link href="{{ route('adminPageMessage') }}" class="flex flex-row items-center">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 mr-2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
                             </svg>
-                            Panel Admin Message
+                            Panel Admin Messages
                         </x-dropdown-link>
                         @endif
 
@@ -236,7 +234,14 @@ new class extends Component
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 mr-2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
                     </svg>
-                    Panel Admin
+                    Panel Admin Posts
+                </x-dropdown-link>
+
+                <x-dropdown-link href="{{ route('adminPageMessage') }}" class="flex flex-row items-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 mr-2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
+                    </svg>
+                    Panel Admin Messages
                 </x-dropdown-link>
                 @endif
                 

--- a/resources/views/livewire/messages/messageBoard.blade.php
+++ b/resources/views/livewire/messages/messageBoard.blade.php
@@ -279,7 +279,7 @@ new class extends Component {
                         </div>
                         @else
                         <div title="{{ $message->updated_at->setTimezone($currentTimeZone)->format($timeFormat) }}"
-                            class="flex flex-row max-w-xs w-auto p-3 rounded-lg bg-gray-300 text-gray-900">
+                            class="flex flex-row max-w-[60%] w-auto p-3 rounded-lg bg-gray-300 text-gray-900">
                             <!-- Signaler -->
                             <button title="Signaler le message"
                                 class="share-button flex items-center text-gray-900 dark:text-gray-900 hover:text-orange-400 dark:hover:text-orange-400 mr-2"
@@ -290,7 +290,7 @@ new class extends Component {
                                         d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
                                     </svg>
                             </button>
-                            <p class="ml-2 w-fit max-w-[100%] break-words">{{ $message->message }}</p>
+                            <p class="ml-2 w-fit max-w-[100%] break-words overflow-hidden">{{ $message->message }}</p>
                         </div>
                         @endif
                     </div>

--- a/resources/views/livewire/messages/report.blade.php
+++ b/resources/views/livewire/messages/report.blade.php
@@ -98,7 +98,7 @@ new class extends Component {
                 <option title="Exemples : contenu pour adulte, suicide..." value="Contenu/Comportement inapproprié">Contenu/Comportement inapproprié</option>
                 <option title="Exemples : attaques personnelles, intimidation..." value="Harcèlement">Harcèlement</option>
                 <option title="Exemples : menaces, encouragement à la violence..." value="Menace ou incitation à la violence">Menace ou incitation à la violence</option>
-                <option title="Exemples : faux profils, usurpation d'identité..." value="Usurpation d'identité">Usurpation d'identité</option>
+                <option title="Exemples : Caractères spéciaux, corrompu, incorrect, dessins inapproprié..." value="Caractères incorrect/corrompu">Caractères incorrect/corrompu</option>
                 <option title="Exemples : escroqueries, fausses promesses, informations trompeuses..." value="Anarque, fraude ou fausses informations">Anarque, fraude ou fausses informations</option>
                 <option title="Exemples : contenu répétitif, trop long inutilement..." value="Spam">Spam</option>         
             </select>


### PR DESCRIPTION
Fonctionnalités et boutons fonctionnels et ajout section "Utilisateurs bannis" Maintenant la section utilisateurs bannis montre seulement les utilisateurs bannis selon l'admin page :
- Si l'admin est sur la page de traitement de report de Post, il verra seulement les bannissement de post
- Si l'admin est sur la page de traitement de report de message, il verra seulement les bannissement de message

Modification menu (mobile/pc) pour bien séparé les 2 menus admin (temporaire) et changement de taille du menu (temporaire) Beaucoup d'ajouts CSS, JavaScript, UI, etc.